### PR TITLE
Spec Modernization - Phase 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'json'
-gem 'json-schema'
+gem 'json_schemer'
 
 group :test do
   gem 'rake',     '~> 10.3'

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ Design principles
 - Properties that allow a ``null`` value can be omitted.
 - Define a `JSON graph schema`_ for content validation purposes.
 
-.. _objects:
+.. _structure:
 
-Objects
+Structure
 -------
 
 .. _node object:
@@ -38,21 +38,21 @@ A node object represents a node in a graph.
 
 **node properties**
 
-- An `id` property is a primary key for an object (see Objects_) that is unique for the object type. Its value is defined as a *JSON string* for flexibility.
+- Each `node` object must contain a string key which is the unique id for the node
 - A `label` property provides a text display for an object. Its value is defined as a *JSON string*.
 - A `metadata` property allows for custom data on an object. Its values is defined as a JSON object.
 
-.. _edge object:
+.. _edge array:
 
-**edge object**
+**edge array**
 
-An edge object represents an edge in a graph.
+Edges are an array of objects, each of which represents an edge in the graph.
 
 **edge properties**
 
-- A `source` property provides the `id` value of the source `node object`_. Its value is defined as a *JSON string*.
+- A `source` property references the `key` value of the source `node object`_. Its value is defined as a *JSON string*.
 - A `relation` property provides the interaction between `source` and `target` nodes.  Its value is defined as a *JSON string*.
-- A `target` property provides the `id` value of the target `node object`_. Its value is defined as a *JSON string*.
+- A `target` property references the `key` value of the target `node object`_. Its value is defined as a *JSON string*.
 - A `directed` property provides the edge mode (e.g. directed or undirected). Its value is *JSON true* for directed and *JSON false* for undirected. The edge direction is determined by *graph.directed* property if not present.
 - A `metadata` property allows for custom data on an object. Its values is defined as a JSON object.
 
@@ -64,6 +64,7 @@ A graph object represents a single conceptual graph.
 
 **graph properties**
 
+- An optional `id` property provides an identifier for this graph object
 - A `type` property provides a classification for an object. Its value is defined as a *JSON string*.
 - A `label` property provides a text display for an object. Its value is defined as a *JSON string*.
 - A `directed` property provides the graph mode (e.g. directed or undirected). Its value is *JSON true* for directed and *JSON false* for undirected. This property default to *JSON true* indicating a directed graph.
@@ -79,11 +80,6 @@ A graphs object groups zero or more `graph object`_ into one JSON document.
 
 - The `graphs object`_ is defined as a *JSON array*.
 
-**graphs properties**
-
-- A `type` property provides a classification for an object. Its value is defined as a *JSON string*.
-- A `label` property provides a text display for an object. Its value is defined as a *JSON string*.
-- A `metadata` property allows for custom data on an object. Its values is defined as a JSON object.
 
 .. _examples:
 
@@ -118,14 +114,12 @@ Examples
 
     {
         "graph": {
-            "nodes": [
-                {
-                    "id": "A",
+            "nodes": {
+                "A": {
                 },
-                {
-                    "id": "B",
+                "B": {
                 }
-            ]
+            }
         }
     }
 
@@ -137,14 +131,12 @@ Examples
 
     {
         "graph": {
-            "nodes": [
-                {
-                    "id": "A",
+            "nodes": {
+                "A": {
                 },
-                {
-                    "id": "B",
+                "B": {
                 }
-            ],
+            },
             "edges": [
                 {
                     "source": "A",
@@ -168,24 +160,22 @@ Examples
             "metadata": {
                 "user-defined": "values"
             },
-            "nodes": [
-                {
-                    "id": "0",
+            "nodes": {
+                "0": {
                     "type": "node type",
                     "label": "node label(0)",
                     "metadata": {
                         "user-defined": "values"
                     }
                 },
-                {
-                    "id": "1",
+                "1": {
                     "type": "node type",
                     "label": "node label(1)",
                     "metadata": {
                         "user-defined": "values"
                     }
                 }
-            ],
+            },
             "edges": [
                 {
                     "source": "0",
@@ -216,24 +206,22 @@ Examples
                 "metadata": {
                     "user-defined": "values"
                 },
-                "nodes": [
-                    {
-                        "id": "0",
+                "nodes": {
+                    "0": {
                         "type": "node type",
                         "label": "node label(0)",
                         "metadata": {
                             "user-defined": "values"
                         }
                     },
-                    {
-                        "id": "1",
+                    "1": {
                         "type": "node type",
                         "label": "node label(1)",
                         "metadata": {
                             "user-defined": "values"
                         }
                     }
-                ],
+                },
                 "edges": [
                     {
                         "source": "0",
@@ -254,24 +242,22 @@ Examples
                 "metadata": {
                     "user-defined": "values"
                 },
-                "nodes": [
-                    {
-                        "id": "0",
+                "nodes": {
+                    "0": {
                         "type": "node type",
                         "label": "node label(0)",
                         "metadata": {
                             "user-defined": "values"
                         }
                     },
-                    {
-                        "id": "1",
+                    "1": {
                         "type": "node type",
                         "label": "node label(1)",
                         "metadata": {
                             "user-defined": "values"
                         }
                     }
-                ],
+                },
                 "edges": [
                     {
                         "source": "1",

--- a/examples/car_graphs.json
+++ b/examples/car_graphs.json
@@ -1,6 +1,7 @@
 {
     "graphs": [
         {
+            "id": "car-manufacturer-relationships",
             "type": "car",
             "label": "Car Manufacturer Relationships",
             "nodes": {
@@ -31,6 +32,7 @@
             ]
         },
         {
+            "id": "car-manufacturer-countries",
             "type": "car",
             "label": "Car Manufacturer Countries",
             "nodes": {

--- a/examples/car_graphs.json
+++ b/examples/car_graphs.json
@@ -3,24 +3,20 @@
         {
             "type": "car",
             "label": "Car Manufacturer Relationships",
-            "nodes": [
-                {
-                    "id": "nissan",
+            "nodes": {
+                "nissan": {
                     "label": "Nissan"
                 },
-                {
-                    "id": "infiniti",
+                "infiniti": {
                     "label": "Infiniti"
                 },
-                {
-                    "id": "toyota",
+                "toyota": {
                     "label": "Toyota"
                 },
-                {
-                    "id": "lexus",
+                "lexus": {
                     "label": "Lexus"
                 }
-            ],
+            },
             "edges": [
                 {
                     "source": "nissan",
@@ -37,20 +33,17 @@
         {
             "type": "car",
             "label": "Car Manufacturer Countries",
-            "nodes": [
-                {
-                    "id": "japan",
+            "nodes": {
+                "japan": {
                     "label": "Japan"
                 },
-                {
-                    "id": "nissan",
+                "nissan": {
                     "label": "Nissan"
                 },
-                {
-                    "id": "toyota",
+                "toyota": {
                     "label": "Toyota"
                 }
-            ],
+            },
             "edges": [
                 {
                     "source": "nissan",

--- a/examples/empty_test.json
+++ b/examples/empty_test.json
@@ -1,0 +1,9 @@
+{
+    "graph": {
+        "type": "schema test",
+        "label": "empty test",
+        "nodes": {},
+        "edges": [],
+        "metadata": {}
+    }
+}

--- a/examples/empty_test.json
+++ b/examples/empty_test.json
@@ -1,5 +1,6 @@
 {
     "graph": {
+        "id": "",
         "type": "schema test",
         "label": "empty test",
         "nodes": {},

--- a/examples/les_miserables.json
+++ b/examples/les_miserables.json
@@ -1,547 +1,470 @@
 {
     "graph": {
         "type": "les miserables",
-        "nodes": [
-            {
+        "nodes": {
+            "Myriel": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Myriel",
                 "label": "Myriel"
             },
-            {
+            "Napoleon": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Napoleon",
                 "label": "Napoleon"
             },
-            {
+            "Mlle.Baptistine": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Mlle.Baptistine",
                 "label": "Mlle.Baptistine"
             },
-            {
+            "Mme.Magloire": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Mme.Magloire",
                 "label": "Mme.Magloire"
             },
-            {
+            "CountessdeLo": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "CountessdeLo",
                 "label": "CountessdeLo"
             },
-            {
+            "Geborand": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Geborand",
                 "label": "Geborand"
             },
-            {
+            "Champtercier": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Champtercier",
                 "label": "Champtercier"
             },
-            {
+            "Cravatte": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Cravatte",
                 "label": "Cravatte"
             },
-            {
+            "Count": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "Count",
                 "label": "Count"
             },
-            {
+            "OldMan": {
                 "metadata": {
                     "group": 1
                 },
-                "id": "OldMan",
                 "label": "OldMan"
             },
-            {
+            "Labarre": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Labarre",
                 "label": "Labarre"
             },
-            {
+            "Valjean": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Valjean",
                 "label": "Valjean"
             },
-            {
+            "Marguerite": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Marguerite",
                 "label": "Marguerite"
             },
-            {
+            "Mme.deR": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Mme.deR",
                 "label": "Mme.deR"
             },
-            {
+            "Isabeau": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Isabeau",
                 "label": "Isabeau"
             },
-            {
+            "Gervais": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Gervais",
                 "label": "Gervais"
             },
-            {
+            "Tholomyes": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Tholomyes",
                 "label": "Tholomyes"
             },
-            {
+            "Listolier": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Listolier",
                 "label": "Listolier"
             },
-            {
+            "Fameuil": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Fameuil",
                 "label": "Fameuil"
             },
-            {
+            "Blacheville": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Blacheville",
                 "label": "Blacheville"
             },
-            {
+            "Favourite": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Favourite",
                 "label": "Favourite"
             },
-            {
+            "Dahlia": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Dahlia",
                 "label": "Dahlia"
             },
-            {
+            "Zephine": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Zephine",
                 "label": "Zephine"
             },
-            {
+            "Fantine": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Fantine",
                 "label": "Fantine"
             },
-            {
+            "Mme.Thenardier": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Mme.Thenardier",
                 "label": "Mme.Thenardier"
             },
-            {
+            "Thenardier": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Thenardier",
                 "label": "Thenardier"
             },
-            {
+            "Cosette": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Cosette",
                 "label": "Cosette"
             },
-            {
+            "Javert": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Javert",
                 "label": "Javert"
             },
-            {
+            "Fauchelevent": {
                 "metadata": {
                     "group": 0
                 },
-                "id": "Fauchelevent",
                 "label": "Fauchelevent"
             },
-            {
+            "Bamatabois": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Bamatabois",
                 "label": "Bamatabois"
             },
-            {
+            "Perpetue": {
                 "metadata": {
                     "group": 3
                 },
-                "id": "Perpetue",
                 "label": "Perpetue"
             },
-            {
+            "Simplice": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Simplice",
                 "label": "Simplice"
             },
-            {
+            "Scaufflaire": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Scaufflaire",
                 "label": "Scaufflaire"
             },
-            {
+            "Woman1": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Woman1",
                 "label": "Woman1"
             },
-            {
+            "Judge": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Judge",
                 "label": "Judge"
             },
-            {
+            "Champmathieu": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Champmathieu",
                 "label": "Champmathieu"
             },
-            {
+            "Brevet": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Brevet",
                 "label": "Brevet"
             },
-            {
+            "Chenildieu": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Chenildieu",
                 "label": "Chenildieu"
             },
-            {
+            "Cochepaille": {
                 "metadata": {
                     "group": 2
                 },
-                "id": "Cochepaille",
                 "label": "Cochepaille"
             },
-            {
+            "Pontmercy": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Pontmercy",
                 "label": "Pontmercy"
             },
-            {
+            "Boulatruelle": {
                 "metadata": {
                     "group": 6
                 },
-                "id": "Boulatruelle",
                 "label": "Boulatruelle"
             },
-            {
+            "Eponine": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Eponine",
                 "label": "Eponine"
             },
-            {
+            "Anzelma": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Anzelma",
                 "label": "Anzelma"
             },
-            {
+            "Woman2": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Woman2",
                 "label": "Woman2"
             },
-            {
+            "MotherInnocent": {
                 "metadata": {
                     "group": 0
                 },
-                "id": "MotherInnocent",
                 "label": "MotherInnocent"
             },
-            {
+            "Gribier": {
                 "metadata": {
                     "group": 0
                 },
-                "id": "Gribier",
                 "label": "Gribier"
             },
-            {
+            "Jondrette": {
                 "metadata": {
                     "group": 7
                 },
-                "id": "Jondrette",
                 "label": "Jondrette"
             },
-            {
+            "Mme.Burgon": {
                 "metadata": {
                     "group": 7
                 },
-                "id": "Mme.Burgon",
                 "label": "Mme.Burgon"
             },
-            {
+            "Gavroche": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Gavroche",
                 "label": "Gavroche"
             },
-            {
+            "Gillenormand": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Gillenormand",
                 "label": "Gillenormand"
             },
-            {
+            "Magnon": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Magnon",
                 "label": "Magnon"
             },
-            {
+            "Mlle.Gillenormand": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Mlle.Gillenormand",
                 "label": "Mlle.Gillenormand"
             },
-            {
+            "Mme.Pontmercy": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Mme.Pontmercy",
                 "label": "Mme.Pontmercy"
             },
-            {
+            "Mlle.Vaubois": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Mlle.Vaubois",
                 "label": "Mlle.Vaubois"
             },
-            {
+            "Lt.Gillenormand": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Lt.Gillenormand",
                 "label": "Lt.Gillenormand"
             },
-            {
+            "Marius": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Marius",
                 "label": "Marius"
             },
-            {
+            "BaronessT": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "BaronessT",
                 "label": "BaronessT"
             },
-            {
+            "Mabeuf": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Mabeuf",
                 "label": "Mabeuf"
             },
-            {
+            "Enjolras": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Enjolras",
                 "label": "Enjolras"
             },
-            {
+            "Combeferre": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Combeferre",
                 "label": "Combeferre"
             },
-            {
+            "Prouvaire": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Prouvaire",
                 "label": "Prouvaire"
             },
-            {
+            "Feuilly": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Feuilly",
                 "label": "Feuilly"
             },
-            {
+            "Courfeyrac": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Courfeyrac",
                 "label": "Courfeyrac"
             },
-            {
+            "Bahorel": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Bahorel",
                 "label": "Bahorel"
             },
-            {
+            "Bossuet": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Bossuet",
                 "label": "Bossuet"
             },
-            {
+            "Joly": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Joly",
                 "label": "Joly"
             },
-            {
+            "Grantaire": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Grantaire",
                 "label": "Grantaire"
             },
-            {
+            "MotherPlutarch": {
                 "metadata": {
                     "group": 9
                 },
-                "id": "MotherPlutarch",
                 "label": "MotherPlutarch"
             },
-            {
+            "Gueulemer": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Gueulemer",
                 "label": "Gueulemer"
             },
-            {
+            "Babet": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Babet",
                 "label": "Babet"
             },
-            {
+            "Claquesous": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Claquesous",
                 "label": "Claquesous"
             },
-            {
+            "Montparnasse": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Montparnasse",
                 "label": "Montparnasse"
             },
-            {
+            "Toussaint": {
                 "metadata": {
                     "group": 5
                 },
-                "id": "Toussaint",
                 "label": "Toussaint"
             },
-            {
+            "Child1": {
                 "metadata": {
                     "group": 10
                 },
-                "id": "Child1",
                 "label": "Child1"
             },
-            {
+            "Child2": {
                 "metadata": {
                     "group": 10
                 },
-                "id": "Child2",
                 "label": "Child2"
             },
-            {
+            "Brujon": {
                 "metadata": {
                     "group": 4
                 },
-                "id": "Brujon",
                 "label": "Brujon"
             },
-            {
+            "Mme.Hucheloup": {
                 "metadata": {
                     "group": 8
                 },
-                "id": "Mme.Hucheloup",
                 "label": "Mme.Hucheloup"
             }
-        ],
+        },
         "edges": [
             {
                 "source": "Napoleon",

--- a/examples/les_miserables.json
+++ b/examples/les_miserables.json
@@ -1,6 +1,7 @@
 {
     "graph": {
-        "type": "les miserables",
+        "id": "les_miserables",
+        "type": "performance",
         "nodes": {
             "Myriel": {
                 "metadata": {

--- a/examples/test.network.json
+++ b/examples/test.network.json
@@ -1,69 +1,70 @@
 {
     "graph": {
-        "nodes": [{
-            "metadata": {
-                "yloc": 105,
-                "xloc": 265
-            },
-            "id": "p(HGNC:LTA)",
-            "label": "p(HGNC:LTA)"
-        }, {
-            "metadata": {
-                "yloc": 30,
-                "xloc": 45
-            },
-            "id": "r(HGNC:IFNG)",
-            "label": "r(HGNC:IFNG)"
-        }, {
-            "metadata": {
-                "yloc": 230,
-                "xloc": 165
-            },
-            "id": "bp(GO:\"T-helper 1 type immune response\")",
-            "label": "bp(GO:\"T-helper 1 type immune response\")"
-        }, {
-            "metadata": {
-                "yloc": 30,
-                "xloc": 265
-            },
-            "id": "r(HGNC:LTA)",
-            "label": "r(HGNC:LTA)"
-        }, {
-            "metadata": {
-                "yloc": 30,
-                "xloc": 155
-            },
-            "id": "r(HGNC:IL2)",
-            "label": "r(HGNC:IL2)"
-        }, {
-            "metadata": {
-                "yloc": 30,
-                "xloc": 375
-            },
-            "id": "r(HGNC:LTB)",
-            "label": "r(HGNC:LTB)"
-        }, {
-            "metadata": {
-                "yloc": 105,
-                "xloc": 45
-            },
-            "id": "p(HGNC:IFNG)",
-            "label": "p(HGNC:IFNG)"
-        }, {
-            "metadata": {
-                "yloc": 105,
-                "xloc": 155
-            },
-            "id": "p(HGNC:IL2)",
-            "label": "p(HGNC:IL2)"
-        }, {
-            "metadata": {
-                "yloc": 105,
-                "xloc": 375
-            },
-            "id": "p(HGNC:LTB)",
-            "label": "p(HGNC:LTB)"
-        }],
+        "nodes": {
+            "p(HGNC:LTA)": {
+                "metadata": {
+                    "yloc": 105,
+                    "xloc": 265
+                },
+                "label": "p(HGNC:LTA)"
+            }, 
+            "r(HGNC:IFNG)": {
+                "metadata": {
+                    "yloc": 30,
+                    "xloc": 45
+                },
+                "label": "r(HGNC:IFNG)"
+            }, 
+            "bp(GO:\"T-helper 1 type immune response\")": {
+                "metadata": {
+                    "yloc": 230,
+                    "xloc": 165
+                },
+                "label": "bp(GO:\"T-helper 1 type immune response\")"
+            }, 
+            "r(HGNC:LTA)": {
+                "metadata": {
+                    "yloc": 30,
+                    "xloc": 265
+                },
+                "label": "r(HGNC:LTA)"
+            }, 
+            "r(HGNC:IL2)": {
+                "metadata": {
+                    "yloc": 30,
+                    "xloc": 155
+                },
+                "label": "r(HGNC:IL2)"
+            }, 
+            "r(HGNC:LTB)": {
+                "metadata": {
+                    "yloc": 30,
+                    "xloc": 375
+                },
+                "label": "r(HGNC:LTB)"
+            }, 
+            "p(HGNC:IFNG)": {
+                "metadata": {
+                    "yloc": 105,
+                    "xloc": 45
+                },
+                "label": "p(HGNC:IFNG)"
+            }, 
+            "p(HGNC:IL2)": {
+                "metadata": {
+                    "yloc": 105,
+                    "xloc": 155
+                },
+                "label": "p(HGNC:IL2)"
+            }, 
+            "p(HGNC:LTB)": {
+                "metadata": {
+                    "yloc": 105,
+                    "xloc": 375
+                },
+                "label": "p(HGNC:LTB)"
+            }
+        },
         "edges": [{
             "source": "r(HGNC:IL2)",
             "relation": "translatedTo",

--- a/examples/usual_suspects.json
+++ b/examples/usual_suspects.json
@@ -2,23 +2,21 @@
     "graph": {
         "type": "movie characters",
         "label": "Usual Suspects",
-        "nodes": [
-            {
-                "id": "Roger Kint",
+        "nodes": {
+            "Roger Kint": {
                 "label": "Roger Kint",
                 "metadata": {
                     "nickname": "Verbal",
                     "actor": "Kevin Spacey"
                 }
             },
-            {
-                "id": "Keyser Söze",
+            "Keyser Söze": {
                 "label": "Keyser Söze",
                 "metadata": {
                     "actor": "Kevin Spacey"
                 }
             }
-        ],
+        },
         "edges": [
             {
                 "source": "Roger Kint",

--- a/examples/usual_suspects.json
+++ b/examples/usual_suspects.json
@@ -1,5 +1,6 @@
 {
     "graph": {
+        "id": "Usual Suspects",
         "type": "movie characters",
         "label": "Usual Suspects",
         "nodes": {

--- a/json-graph-schema.json
+++ b/json-graph-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://jsongraphformat.info/json-graph-schema.json",
+  "$id": "http://jsongraphformat.info/v2.0/json-graph-schema.json",
   "title": "JSON Graph Schema",
   "oneOf": [
     {
@@ -55,15 +55,17 @@
         },
         "nodes": {
           "type": "object",
-          "properties": {
-            "label": {
-              "type": "string"
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object"
+              }
             },
-            "metadata": {
-              "type": [
-                "object"
-              ]
-            }
+            "additionalProperties": false
           }
         },
         "edges": {

--- a/json-graph-schema.json
+++ b/json-graph-schema.json
@@ -1,139 +1,113 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
-    "oneOf": [
-        {
-            "type": "object",
-            "properties": {
-                "graph": {
-                    "$ref": "#/definitions/graph"
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "graph"
-            ]
-        },
-        {
-            "type": "object",
-            "properties": {
-                "label": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": [
-                        "object",
-                        "null"
-                    ]
-                },
-                "graphs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/graph"
-                    }
-                }
-            },
-            "additionalProperties": false
-        }
-    ],
-    "definitions": {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://jsongraphformat.info/json-graph-schema.json",
+  "title": "JSON Graph Schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
         "graph": {
+          "$ref": "#/definitions/graph"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "graph"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "graphs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "graph": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "directed": {
+          "type": [
+            "boolean"
+          ],
+          "default": true
+        },
+        "type": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": [
+            "object"
+          ]
+        },
+        "nodes": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "metadata": {
+              "type": [
+                "object"
+              ]
+            }
+          }
+        },
+        "edges": {
+          "type": [
+            "array"
+          ],
+          "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "label": {
-                    "type": "string"
-                },
-                "directed": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ],
-                    "default": true
-                },
-                "type": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": [
-                        "object",
-                        "null"
-                    ]
-                },
-                "nodes": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "label": {
-                                "type": "string"
-                            },
-                            "metadata": {
-                                "type": [
-                                    "object",
-                                    "null"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "id"
-                        ]
-                    }
-                },
-                "edges": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "source": {
-                                "type": "string"
-                            },
-                            "target": {
-                                "type": "string"
-                            },
-                            "relation": {
-                                "type": "string"
-                            },
-                            "directed": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "default": true
-                            },
-                            "label": {
-                                "type": "string"
-                            },
-                            "metadata": {
-                                "type": [
-                                    "object",
-                                    "null"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "source",
-                            "target"
-                        ]
-                    }
-                }
-            }
+              "id": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              },
+              "relation": {
+                "type": "string"
+              },
+              "directed": {
+                "type": [
+                  "boolean"
+                ],
+                "default": true
+              },
+              "label": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": [
+                  "object"
+                ]
+              }
+            },
+            "required": [
+              "source",
+              "target"
+            ]
+          }
         }
+      }
     }
+  }
 }

--- a/test/json-schema-draft7.json
+++ b/test/json-schema-draft7.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": {"$ref": "#"},
+        "then": {"$ref": "#"},
+        "else": {"$ref": "#"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/test/test-examples.rb
+++ b/test/test-examples.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'json-schema'
+require 'json_schemer'
 require 'pathname'
 require 'minitest/autorun'
 require 'minitest/unit'
@@ -14,15 +14,14 @@ class ExamplesTest < Minitest::Unit::TestCase
 
   def test_examples
     @examples.each do |ex|
+      puts "-------\nExample: #{ex}"
       data = JSON.parse File.open(ex, 'r:UTF-8', &:read)
-      errors = JSON::Validator.fully_validate(@schema, data, :insert_defaults => true)
+      schemer = JSONSchemer.schema(@schema)
+      
+      assert schemer.valid?(data)
+      errors = schemer.validate(data)
+      assert errors.none?
 
-      if ENV['JGS_VERBOSE']
-        puts "\n\nValidated JSON for example: #{ex}"
-        pp data
-      end
-
-      assert errors.empty?, errors.join("\n")
     end
   end
 end

--- a/test/test-schema.rb
+++ b/test/test-schema.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'json-schema'
+require 'json_schemer'
 require "minitest/autorun"
 require "minitest/unit"
 
@@ -7,10 +7,13 @@ class SchemaTest < Minitest::Unit::TestCase
 
   def test_validate_schema
     root   = Pathname(File.dirname(File.expand_path __FILE__)) + '..'
+    draft = JSON.parse File.read(root + 'test/json-schema-draft7.json')
     schema = JSON.parse File.read(root + 'json-graph-schema.json')
-    errors = JSON::Validator.fully_validate_schema(schema)
 
-    assert errors.empty?, errors.join("\n")
+    schemer = JSONSchemer.schema(draft)
+    assert schemer.valid?(schema)
+    errors = schemer.validate(schema)
+    assert errors.none?
   end
 end
 # vim: ts=2 sts=2 sw=2


### PR DESCRIPTION
Hi all, this is a significant update, I'll do my best to describe everything and start a discussion.

Major topics for discussion:
  1. Update to JSON Schema Draft7
  2. Remove `json-schema` b/c it is no longer supported, replace with `json_schemer` b/c it works for Draft7
  3. Add `$id` and `title` fields to the schema definition, best practices for Draft7
  4. Changed the `nodes` array into keyed objects, as discussed in #39. (Please see important further detail about this change below)
  5. Add `id` field back into the graph object
  6. Simplify the `graphs` array, removing some of the unused properties. Remove `null` types from properties objects, as this is built-in functionality
  7. Phase 2?? What's next (see comments below)

---

**1. Update to JSON Schema Draft7**

There have been some best practices and significant updates since Draft4 came out, so I thought it would be a good idea to update to Draft7. This is my first time implementing a JSON Schema, so if you see anything awry, let me know.

If you'd prefer to keep Draft4 in place, let's start a discussion about that.

**2. Remove `json-schema`. Add `json_schemer`**

`json-schema` is no longer supported, and does not work for Draft7. The only other ruby validator that works for Draft7 is `json_schemer`. I am not super happy with this one, it doesn't have the same functionality, and error code opacity is a problem. It does not support schema validation, so I had to add the Draft7 schema as a file in order to validate that our `json-graph-specification` schema is a valid format.

**3. Add `$id` and `title` fields**

This seems to be best practice for every Draft7 schema that I used as reference. So, adding here as well. We should update the `$id` uri location to somewhere that actually hosts the file - a github.io address, or publish the final json schema to jsongraphformat.info. Not the end of the world if our schema does not exist at the uri, but it is best practice.

I think this should close #27 

**4. Change `nodes` array to objects**

We discussed this mod briefly in #39 and it seemed logical to me. I removed the array and made it an object, removed the `id` property and using it as a key (see examples).

In my estimation, it does not make sense to also turn the `edges` array into keyed objects, because that would _require_ a unique `id` for each edge. As of now the `id` property is not required, and by turning it into objects, it would be required. [This StackOverflow convo](https://stackoverflow.com/questions/43052290/representing-a-graph-in-json) is a pretty good example of the challenge somebody else already faced in this regard.

If approved, should close #39

**5. Add `id` field back to `graph` object**

Should close #32 

**6. Simplify**

Some general housekeeping, cleaning up. See diff and let me know if you have any questions or concerns about the mods, I think they're pretty straightforward.

**7. Phase 2??**

It seems to me there is still some low hanging fruit here. 
  * I'd personally like to see this as a python project instead of ruby, because the validators available are much better.
  * IMO, The documentation needs some updating/improving. Even just switching it away from `rst` to `md` could improve formatting and readability
  * Not sure what you guys want to do about the streaming... I know nothing about that topic


