### PR TITLE
fix(json-graph-schema_v2.json): Correct node definition

### DIFF
--- a/json-graph-schema_v2.json
+++ b/json-graph-schema_v2.json
@@ -89,10 +89,10 @@
     },
     "node": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "label": { "type": "string" },
-        "metadata": { "type": "object" },
-        "additionalProperties": false
+        "metadata": { "type": "object" }
       }
     },
     "edge": {


### PR DESCRIPTION
Move the additionalProperties JSON Schema property into the parent node type definition.

The current node additionalProperties is located in the properties object with an unsupported JSON Scheme type definition. This patch should fix #55 as well as many JSON Schema validation engines.